### PR TITLE
Add firefox-snap-nightly

### DIFF
--- a/firefox-snap/script.sh
+++ b/firefox-snap/script.sh
@@ -9,6 +9,7 @@ process_snap "firefox-snap-esr" "firefox" "mozilla-snaps"
 process_snap "firefox-snap-esr-chemspill" "firefox" "mozilla-snaps"
 process_snap "firefox-snap-beta" "firefox" "mozilla-snaps"
 process_snap "firefox-snap-core22" "firefox" "mozilla-snaps"
+process_snap "firefox-snap-nightly" "firefox" "mozilla-snaps"
 
 zip_symbols
 


### PR DESCRIPTION
The Firefox Nightly snap is now built on Launchpad as well, so its debug symbols need to be collected similarly to the other Firefox snap series.

edit: pinging ~~@lissyx @mkaply~~ @gabrielesvelto for review