### PR TITLE
Add support for debuginfod and optimize the scripts

### DIFF
--- a/arch/script.sh
+++ b/arch/script.sh
@@ -102,7 +102,7 @@ function generate_fake_packages() {
   cat SHA256SUMS | while read line; do
     local package_name=$(echo ${line} | cut -d',' -f1)
     local package_size=$(echo ${line} | cut -d',' -f2)
-    truncate --size "${package_size}" "downloads/${package_name}"
+    truncate -s "${package_size}" "downloads/${package_name}"
   done
 }
 
@@ -170,15 +170,15 @@ function add_package_to_list() {
   local package_filename=$(basename "${1}")
   local package_size=$(stat -c"%s" "${1}")
   printf "${package_filename},${package_size}\n" >> SHA256SUMS
-  truncate --size 0 "${1}"
-  truncate --size "${package_size}" "${1}"
+  truncate -s 0 "${1}"
+  truncate -s "${package_size}" "${1}"
 
   if [ -n "${2}" ]; then
     local debuginfo_package_filename=$(basename "${2}")
     local debuginfo_package_size=$(stat -c"%s" "${2}")
     printf "${debuginfo_package_filename},${debuginfo_package_size}\n" >> SHA256SUMS
-    truncate --size 0 "${2}"
-    truncate --size "${debuginfo_package_size}" "${2}"
+    truncate -s 0 "${2}"
+    truncate -s "${debuginfo_package_size}" "${2}"
   fi
 }
 
@@ -190,7 +190,7 @@ function process_packages() {
       local version=$(get_version "${package_name}" "${package_filename}")
       local debuginfo_package=$(find_debuginfo_package "${package_name}" "${version}")
 
-      truncate --size=0 error.log
+      truncate -s 0 error.log
 
       if [ -n "${debuginfo_package}" ]; then
         unpack_package "${package}" "${debuginfo_package}"

--- a/arch/script.sh
+++ b/arch/script.sh
@@ -148,6 +148,7 @@ libx11
 libxcb
 libxext
 libxkbcommon
+llvm-libs
 mesa
 nspr
 nss

--- a/arch/script.sh
+++ b/arch/script.sh
@@ -116,6 +116,7 @@ atk
 at-spi2-atk
 at-spi2-core
 cairo
+jemalloc
 libcups
 dbus
 dbus-glib
@@ -127,8 +128,10 @@ gcc-libs
 gdk-pixbuf2
 glib2
 glibc
+gperftools
 gtk3
 gvfs
+highway
 intel-gmmlib
 intel-media-driver
 libdrm

--- a/arch/script.sh
+++ b/arch/script.sh
@@ -44,14 +44,20 @@ function fetch_packages() {
 
   echo "${1}" | while read line; do
     [ -z "${line}" ] && continue
-    get_package_urls ${line} >> packages.txt
+    get_package_urls ${line} >> unfiltered-packages.txt
   done
 
   find . -name "index.html*" -exec rm -f {} \;
 
-  wget -o wget_packages.log --progress=dot:mega -P downloads -c -i packages.txt
+  touch packages.txt
+  cat unfiltered-packages.txt | while read line; do
+    package_name=$(echo "${line}" | rev | cut -d'/' -f1 | rev)
+    if ! grep -q -F "${package_name}" SHA256SUMS; then
+      echo "${line}" >> packages.txt
+    fi
+  done
 
-  rev packages.txt | cut -d'/' -f1 | rev > package_names.txt
+  sort packages.txt | wget -o wget_packages.log --progress=dot:mega -P downloads -c -i -
 }
 
 function get_version() {
@@ -95,20 +101,13 @@ function find_debuginfo() {
 }
 
 function remove_temp_files() {
-  rm -rf symbols packages debug-packages tmp symbols*.zip packages.txt package_names.txt
-}
-
-function generate_fake_packages() {
-  cat SHA256SUMS | while read line; do
-    local package_name=$(echo ${line} | cut -d',' -f1)
-    local package_size=$(echo ${line} | cut -d',' -f2)
-    truncate -s "${package_size}" "downloads/${package_name}"
-  done
+  rm -rf downloads symbols packages debug-packages tmp \
+         symbols*.zip indexes.txt packages.txt unfiltered-packages.txt \
+         crashes.list symbols.list
 }
 
 remove_temp_files
 mkdir -p downloads symbols tmp
-generate_fake_packages
 
 packages="
 amdvlk
@@ -166,85 +165,66 @@ x265
 
 fetch_packages "${packages}"
 
-function add_package_to_list() {
-  local package_filename=$(basename "${1}")
-  local package_size=$(stat -c"%s" "${1}")
-  printf "${package_filename},${package_size}\n" >> SHA256SUMS
-  truncate -s 0 "${1}"
-  truncate -s "${package_size}" "${1}"
-
-  if [ -n "${2}" ]; then
-    local debuginfo_package_filename=$(basename "${2}")
-    local debuginfo_package_size=$(stat -c"%s" "${2}")
-    printf "${debuginfo_package_filename},${debuginfo_package_size}\n" >> SHA256SUMS
-    truncate -s 0 "${2}"
-    truncate -s "${debuginfo_package_size}" "${2}"
-  fi
-}
-
 function process_packages() {
   local package_name="${1}"
   find downloads -name "${package_name}-[0-9]*.pkg.tar.zst" -type f | while read package; do
     local package_filename="${package##downloads/}"
-    if ! grep -q -F "${package_filename}" SHA256SUMS; then
-      local version=$(get_version "${package_name}" "${package_filename}")
-      local debuginfo_package=$(find_debuginfo_package "${package_name}" "${version}")
+    local version=$(get_version "${package_name}" "${package_filename}")
+    local debuginfo_package=$(find_debuginfo_package "${package_name}" "${version}")
 
-      truncate -s 0 error.log
+    truncate -s 0 error.log
 
-      if [ -n "${debuginfo_package}" ]; then
-        unpack_package "${package}" "${debuginfo_package}"
-      else
-        printf "***** Could not find debuginfo for ${package_filename}\n"
-        unpack_package "${package}"
-      fi
-
-      find packages -type f | while read path; do
-        if file "${path}" | grep -q ": *ELF" ; then
-          local debuginfo_path="$(find_debuginfo "${path}")"
-
-          local tmpfile=$(mktemp --tmpdir=tmp)
-          printf "Writing symbol file for ${path} ${debuginfo_path} ... "
-          if [ -n "${debuginfo_path}" ]; then
-            ${DUMP_SYMS} --inlines "${path}" "${debuginfo_path}" 1> "${tmpfile}" 2> error.log
-          else
-            ${DUMP_SYMS} --inlines "${path}" 1> "${tmpfile}" 2> error.log
-          fi
-
-          if [ -s "${tmpfile}" -a -z "${debuginfo_path}" ]; then
-            printf "done w/o debuginfo\n"
-          elif [ -s "${tmpfile}" ]; then
-            printf "done\n"
-          else
-            printf "something went terribly wrong!\n"
-          fi
-
-          if [ -s error.log ]; then
-            printf "***** error log for package ${package} ${path} ${debuginfo_path}\n"
-            cat error.log
-            printf "***** error log for package ${package} ${path} ${debuginfo_path} ends here\n"
-          fi
-
-          # Copy the symbol file
-          debugid=$(head -n 1 "${tmpfile}" | cut -d' ' -f4)
-          filename="$(basename "${path}")"
-          mkdir -p "symbols/${filename}/${debugid}"
-          cp "${tmpfile}" "symbols/${filename}/${debugid}/${filename}.sym"
-          local soname=$(get_soname "${path}")
-          if [ -n "${soname}" ]; then
-            if [ "${soname}" != "${filename}" ]; then
-              mkdir -p "symbols/${soname}/${debugid}"
-              cp "${tmpfile}" "symbols/${soname}/${debugid}/${soname}.sym"
-            fi
-          fi
-
-          rm -f "${tmpfile}"
-        fi
-      done
-
-      rm -rf packages debug-packages
-      add_package_to_list "${package}" "${debuginfo_package}"
+    if [ -n "${debuginfo_package}" ]; then
+      unpack_package "${package}" "${debuginfo_package}"
+    else
+      printf "***** Could not find debuginfo for ${package_filename}\n"
+      unpack_package "${package}"
     fi
+
+    find packages -type f | while read path; do
+      if file "${path}" | grep -q ": *ELF" ; then
+        local debuginfo_path="$(find_debuginfo "${path}")"
+
+        local tmpfile=$(mktemp --tmpdir=tmp)
+        printf "Writing symbol file for ${path} ${debuginfo_path} ... "
+        if [ -n "${debuginfo_path}" ]; then
+          ${DUMP_SYMS} --inlines "${path}" "${debuginfo_path}" 1> "${tmpfile}" 2> error.log
+        else
+          ${DUMP_SYMS} --inlines "${path}" 1> "${tmpfile}" 2> error.log
+        fi
+
+        if [ -s "${tmpfile}" -a -z "${debuginfo_path}" ]; then
+          printf "done w/o debuginfo\n"
+        elif [ -s "${tmpfile}" ]; then
+          printf "done\n"
+        else
+          printf "something went terribly wrong!\n"
+        fi
+
+        if [ -s error.log ]; then
+          printf "***** error log for package ${package} ${path} ${debuginfo_path}\n"
+          cat error.log
+          printf "***** error log for package ${package} ${path} ${debuginfo_path} ends here\n"
+        fi
+
+        # Copy the symbol file
+        debugid=$(head -n 1 "${tmpfile}" | cut -d' ' -f4)
+        filename="$(basename "${path}")"
+        mkdir -p "symbols/${filename}/${debugid}"
+        cp "${tmpfile}" "symbols/${filename}/${debugid}/${filename}.sym"
+        local soname=$(get_soname "${path}")
+        if [ -n "${soname}" ]; then
+          if [ "${soname}" != "${filename}" ]; then
+            mkdir -p "symbols/${soname}/${debugid}"
+            cp "${tmpfile}" "symbols/${soname}/${debugid}/${soname}.sym"
+          fi
+        fi
+
+        rm -f "${tmpfile}"
+      fi
+    done
+
+    rm -rf packages debug-packages
   done
 }
 
@@ -258,5 +238,7 @@ zip_symbols
 upload_symbols
 
 reprocess_crashes
+
+update_sha256sums
 
 remove_temp_files

--- a/arch/script.sh
+++ b/arch/script.sh
@@ -34,7 +34,7 @@ function get_package_indexes() {
 function fetch_packages() {
   get_package_indexes
 
-  wget -o wget_packages_urls.log --progress=dot:mega --compression=auto -k -i indexes.txt
+  wget --waitretry=100 --retry-on-http-error=429 -o wget_packages_urls.log --progress=dot:mega --compression=auto -k -i indexes.txt
 
   find . -name "index.html*" | while read path; do
     mv "${path}" "${path}.bak"
@@ -57,7 +57,7 @@ function fetch_packages() {
     fi
   done
 
-  sort packages.txt | wget -o wget_packages.log --progress=dot:mega -P downloads -c -i -
+  sort packages.txt | wget --waitretry=100 --retry-on-http-error=429 -o wget_packages.log --progress=dot:mega -P downloads -c -i -
 }
 
 function get_version() {

--- a/arch/script.sh
+++ b/arch/script.sh
@@ -233,7 +233,7 @@ echo "${packages}" | while read line; do
   process_packages ${line}
 done
 
-zip_symbols
+create_symbols_archive
 
 upload_symbols
 

--- a/arch/script.sh
+++ b/arch/script.sh
@@ -34,7 +34,7 @@ function get_package_indexes() {
 function fetch_packages() {
   get_package_indexes
 
-  wget --waitretry=100 --retry-on-http-error=429 -o wget_packages_urls.log --progress=dot:mega --compression=auto -k -i indexes.txt
+  ${WGET} -o wget_packages_urls.log -k -i indexes.txt
 
   find . -name "index.html*" | while read path; do
     mv "${path}" "${path}.bak"
@@ -57,7 +57,7 @@ function fetch_packages() {
     fi
   done
 
-  sort packages.txt | wget --waitretry=100 --retry-on-http-error=429 -o wget_packages.log --progress=dot:mega -P downloads -c -i -
+  sort packages.txt | ${WGET} -o wget_packages.log -P downloads -c -i -
 }
 
 function get_version() {

--- a/common.sh
+++ b/common.sh
@@ -169,3 +169,6 @@ if ! is_taskcluster; then
     exit 1
   fi
 fi
+
+# wget with common options to retry, compress the requests, etc...
+WGET="wget --waitretry=100 --retry-on-http-error=429 --progress=dot:mega --compression=auto"

--- a/common.sh
+++ b/common.sh
@@ -82,9 +82,9 @@ function get_soname {
   fi
 }
 
-function zip_symbols() {
+function create_symbols_archive() {
   cd symbols
-  zip -r -9 "../${artifact_filename}" .
+  7zz a "../${artifact_filename}" $(ls -A)
   cd ..
 }
 

--- a/common.sh
+++ b/common.sh
@@ -117,6 +117,7 @@ function reprocess_crashes()
   if ! is_taskcluster; then
     find symbols -name "*.sym" -type f > symbols.list
 
+    touch crashes.list
     cat symbols.list | while read symfile; do
       debug_id=$(head -n1 "${symfile}" | cut -d' ' -f4)
       module_name=$(head -n2 "${symfile}" | tail -n1 | cut -d' ' -f4)
@@ -142,6 +143,12 @@ function reprocess_crashes()
       fi
     fi
   fi
+}
+
+function update_sha256sums() {
+  # We store the package names along with the current date, we will use these dates
+  # in the future but for the time being we just need a package-name,number format.
+  cat unfiltered-packages.txt | rev | cut -d'/' -f1 | rev | sed -e "s/$/,$(date "+%s")/" > SHA256SUMS
 }
 
 if [ -z "${DUMP_SYMS}" ]; then

--- a/common.sh
+++ b/common.sh
@@ -59,8 +59,16 @@ function find_debuginfo() {
   fi
 
   # this was from opensuse's find_debug_info
-  if [ ! -e "${debuginfo}" ]; then
-    find packages/usr/lib/debug -name $(basename "${1}")-"${2}".debug -type f | head -n 1
+  if [ \( -z "${debuginfo}" \) -a \( -d "packages/usr/lib/debug" \) ]; then
+    debuginfo=$(find "packages/usr/lib/debug" -name $(basename "${1}")-"${2}".debug -type f | head -n 1)
+  fi
+
+  if [ -z "${debuginfo}" ]; then
+    debuginfo=$(debuginfod-find debuginfo "${buildid}" 2>/dev/null)
+
+    if [ $? -ne 0 ]; then
+      debuginfo="" # Discard debuginfod-find output on failure
+    fi
   fi
 
   printf "${debuginfo}"

--- a/debian/script.sh
+++ b/debian/script.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+export DEBUGINFOD_URLS="https://debuginfod.debian.net/"
+
 . $(dirname $0)/../common.sh
 
 URL="http://deb.debian.org/debian/pool"

--- a/debian/script.sh
+++ b/debian/script.sh
@@ -28,9 +28,16 @@ get_package_urls() {
   fi
 
   wget -o wget_packages_urls.log --progress=dot:mega -k ${urls}
-  for i in ${urls}; do
-    find . -name "index.html*" -exec grep -o "${i}\(${package_name}\|${dbg_package_name}-dbg\|${dbgsym_package_name}-dbgsym\)_.*_\(i386\|amd64\).deb\"" {} \; | cut -d'"' -f1
-  done
+  find . -name "index.html*" -exec grep -o "${url}/${main_path}/\(${package_name}\|${dbg_package_name}-dbg\|${dbgsym_package_name}-dbgsym\)_.*_\(i386\|amd64\).deb\"" {} \; | cut -d'"' -f1
+  find . -name "index.html*" -exec grep -o "${url}/${non_free_path}/\(${package_name}\|${dbg_package_name}-dbg\|${dbgsym_package_name}-dbgsym\)_.*_\(i386\|amd64\).deb\"" {} \; | cut -d'"' -f1
+  find . -name "index.html*" -exec grep -o "${ddeb_url}/${main_path}/\(${package_name}\|${dbg_package_name}-dbg\|${dbgsym_package_name}-dbgsym\)_.*_\(i386\|amd64\).deb\"" {} \; | cut -d'"' -f1
+  find . -name "index.html*" -exec grep -o "${ddeb_url}/${non_free_path}/\(${package_name}\|${dbg_package_name}-dbg\|${dbgsym_package_name}-dbgsym\)_.*_\(i386\|amd64\).deb\"" {} \; | cut -d'"' -f1
+
+  if [ -n "${alt_url}" ]; then
+    find . -name "index.html*" -exec grep -o "${alt_url}/${main_path}/\(${package_name}\|${dbg_package_name}-dbg\|${dbgsym_package_name}-dbgsym\)_.*_\(i386\|amd64\).deb\"" {} \; | cut -d'"' -f1
+    find . -name "index.html*" -exec grep -o "${ddeb_alt_url}/${main_path}/\(${package_name}\|${dbg_package_name}-dbg\|${dbgsym_package_name}-dbgsym\)_.*_\(i386\|amd64\).deb\"" {} \; | cut -d'"' -f1
+  fi
+
   find . -name "index.html*" -exec rm -f {} \;
 }
 

--- a/debian/script.sh
+++ b/debian/script.sh
@@ -27,7 +27,7 @@ get_package_urls() {
     urls="${urls} ${alt_url}/${main_path}/ ${ddeb_alt_url}/${main_path}/"
   fi
 
-  wget --waitretry=100 --retry-on-http-error=429 -o wget_packages_urls.log --progress=dot:mega -k ${urls}
+  ${WGET} -o wget_packages_urls.log -k ${urls}
   find . -name "index.html*" -exec grep -o "${url}/${main_path}/\(${package_name}\|${dbg_package_name}-dbg\|${dbgsym_package_name}-dbgsym\)_.*_\(i386\|amd64\).deb\"" {} \; | cut -d'"' -f1
   find . -name "index.html*" -exec grep -o "${url}/${non_free_path}/\(${package_name}\|${dbg_package_name}-dbg\|${dbgsym_package_name}-dbgsym\)_.*_\(i386\|amd64\).deb\"" {} \; | cut -d'"' -f1
   find . -name "index.html*" -exec grep -o "${ddeb_url}/${main_path}/\(${package_name}\|${dbg_package_name}-dbg\|${dbgsym_package_name}-dbgsym\)_.*_\(i386\|amd64\).deb\"" {} \; | cut -d'"' -f1
@@ -56,7 +56,7 @@ fetch_packages() {
   done
 
   sed -i -e 's/%2b/+/g' packages.txt
-  sort packages.txt | wget --waitretry=100 --retry-on-http-error=429 -o wget_packages.log --progress=dot:mega -P downloads -c -i -
+  sort packages.txt | ${WGET} -o wget_packages.log -P downloads -c -i -
 }
 
 function get_version() {

--- a/debian/script.sh
+++ b/debian/script.sh
@@ -77,20 +77,20 @@ function unpack_package() {
   local debug_package_name="${2}"
   mkdir packages
   data_file=$(ar t "${package_name}" | grep ^data)
-  ar x "${package_name}" && \
+  ar x "${package_name}" "${data_file}" && \
   tar -C packages -x -a -f "${data_file}"
   if [ $? -ne 0 ]; then
     printf "Failed to extract ${package_name}\n" 2>>error.log
   fi
-  rm -f data.tar* control.tar* debian-binary
+  rm -f "${data_file}"
   if [ -n "${debug_package_name}" ]; then
     data_file=$(ar t "${package_name}" | grep ^data)
-    ar x "${debug_package_name}" && \
+    ar x "${debug_package_name}" "${data_file}" && \
     tar -C packages -x -a -f "${data_file}"
     if [ $? -ne 0 ]; then
       printf "Failed to extract ${debug_package_name}\n" 2>>error.log
     fi
-    rm -f data.tar* control.tar* debian-binary
+    rm -f "${data_file}"
   fi
 }
 

--- a/debian/script.sh
+++ b/debian/script.sh
@@ -226,8 +226,6 @@ function process_packages() {
       printf "package_name = ${package_name} version = ${version} dbg_package_name = ${debug_package_name}\n"
       local debuginfo_package=$(find_debuginfo_package "${package_name}" "${version}" "${debug_package_name}")
 
-      truncate -s 0 error.log
-
       if [ -n "${debuginfo_package}" ]; then
         unpack_package ${package} ${debuginfo_package}
       else
@@ -239,20 +237,27 @@ function process_packages() {
         if file "${path}" | grep -q ": *ELF" ; then
           local debuginfo_path="$(find_debuginfo "${path}")"
 
-          [ -z "${debuginfo_path}" ] && printf "Could not find debuginfo for ${path}\n" && continue
-
+          truncate -s 0 error.log
           local tmpfile=$(mktemp --tmpdir=tmp)
           printf "Writing symbol file for ${path} ${debuginfo_path} ... "
-          ${DUMP_SYMS} --inlines "${path}" "${debuginfo_path}" 1> "${tmpfile}" 2>>error.log
-          if [ -s "${tmpfile}" ]; then
+          if [ -n "${debuginfo_path}" ]; then
+            ${DUMP_SYMS} --inlines "${path}" "${debuginfo_path}" 1> "${tmpfile}" 2> error.log
+          else
+            ${DUMP_SYMS} --inlines "${path}" 1> "${tmpfile}" 2> error.log
+          fi
+
+          if [ -s "${tmpfile}" -a -z "${debuginfo_path}" ]; then
+            printf "done w/o debuginfo\n"
+          elif [ -s "${tmpfile}" ]; then
             printf "done\n"
           else
-            ${DUMP_SYMS} --inlines "${path}" > "${tmpfile}"
-            if [ -s "${tmpfile}" ]; then
-              printf "done w/o debuginfo\n"
-            else
-              printf "something went terribly wrong!\n"
-            fi
+            printf "something went terribly wrong!\n"
+          fi
+
+          if [ -s error.log ]; then
+            printf "***** error log for package ${package} ${path} ${debuginfo_path}\n"
+            cat error.log
+            printf "***** error log for package ${package} ${path} ${debuginfo_path} ends here\n"
           fi
 
           # Copy the symbol file and debug information
@@ -271,12 +276,6 @@ function process_packages() {
           rm -f "${tmpfile}"
         fi
       done
-
-      if [ -s error.log ]; then
-        printf "***** error log for package ${package}\n"
-        cat error.log
-        printf "***** error log for package ${package} ends here\n"
-      fi
 
       rm -rf packages
     done

--- a/debian/script.sh
+++ b/debian/script.sh
@@ -124,9 +124,9 @@ libatk1.0-0 a/atk1.0
 libatk-bridge2.0-0 a/at-spi2-atk
 libatspi2.0-0 a/at-spi2-core
 libavcodec[0-9][0-9] f/ffmpeg
-libavcodec[0-9][0-9] f/ffmpeg-dmo libavcodec[0-9][0-9] libavcodec[0-9][0-9] http://deb-multimedia.org/debian-multimedia/pool
+libavcodec[0-9][0-9] f/ffmpeg-dmo libavcodec[0-9][0-9] libavcodec[0-9][0-9] http://deb-multimedia.org/pool
 libavutil[0-9][0-9] f/ffmpeg
-libavutil[0-9][0-9] f/ffmpeg-dmo libavutil[0-9][0-9] libavutil[0-9][0-9] http://deb-multimedia.org/debian-multimedia/pool
+libavutil[0-9][0-9] f/ffmpeg-dmo libavutil[0-9][0-9] libavutil[0-9][0-9] http://deb-multimedia.org/pool
 libc6 g/glibc
 libcairo2 c/cairo
 libcups2 c/cups

--- a/debian/script.sh
+++ b/debian/script.sh
@@ -286,7 +286,7 @@ echo "${packages}" | while read line; do
   process_packages ${line}
 done
 
-zip_symbols
+create_symbols_archive
 
 upload_symbols
 

--- a/debian/script.sh
+++ b/debian/script.sh
@@ -102,7 +102,7 @@ function generate_fake_packages() {
   cat SHA256SUMS | while read line; do
     local package_name=$(echo ${line} | cut -d',' -f1)
     local package_size=$(echo ${line} | cut -d',' -f2)
-    truncate --size "${package_size}" "downloads/${package_name}"
+    truncate -s "${package_size}" "downloads/${package_name}"
   done
 }
 
@@ -218,15 +218,15 @@ function add_package_to_list() {
   local package_filename=$(basename "${1}")
   local package_size=$(stat -c"%s" "${1}")
   printf "${package_filename},${package_size}\n" >> SHA256SUMS
-  truncate --size 0 "${1}"
-  truncate --size "${package_size}" "${1}"
+  truncate -s 0 "${1}"
+  truncate -s "${package_size}" "${1}"
 
   if [ -n "${2}" ]; then
     local debuginfo_package_filename=$(basename "${2}")
     local debuginfo_package_size=$(stat -c"%s" "${2}")
     printf "${debuginfo_package_filename},${debuginfo_package_size}\n" >> SHA256SUMS
-    truncate --size 0 "${2}"
-    truncate --size "${debuginfo_package_size}" "${2}"
+    truncate -s 0 "${2}"
+    truncate -s "${debuginfo_package_size}" "${2}"
   fi
 }
 
@@ -241,7 +241,7 @@ function process_packages() {
         printf "package_name = ${package_name} version = ${version} dbg_package_name = ${debug_package_name}\n"
         local debuginfo_package=$(find_debuginfo_package "${package_name}" "${version}" "${debug_package_name}")
 
-        truncate --size=0 error.log
+        truncate -s 0 error.log
 
         if [ -n "${debuginfo_package}" ]; then
           unpack_package ${package} ${debuginfo_package}

--- a/debian/script.sh
+++ b/debian/script.sh
@@ -27,7 +27,7 @@ get_package_urls() {
     urls="${urls} ${alt_url}/${main_path}/ ${ddeb_alt_url}/${main_path}/"
   fi
 
-  wget -o wget_packages_urls.log --progress=dot:mega -k ${urls}
+  wget --waitretry=100 --retry-on-http-error=429 -o wget_packages_urls.log --progress=dot:mega -k ${urls}
   find . -name "index.html*" -exec grep -o "${url}/${main_path}/\(${package_name}\|${dbg_package_name}-dbg\|${dbgsym_package_name}-dbgsym\)_.*_\(i386\|amd64\).deb\"" {} \; | cut -d'"' -f1
   find . -name "index.html*" -exec grep -o "${url}/${non_free_path}/\(${package_name}\|${dbg_package_name}-dbg\|${dbgsym_package_name}-dbgsym\)_.*_\(i386\|amd64\).deb\"" {} \; | cut -d'"' -f1
   find . -name "index.html*" -exec grep -o "${ddeb_url}/${main_path}/\(${package_name}\|${dbg_package_name}-dbg\|${dbgsym_package_name}-dbgsym\)_.*_\(i386\|amd64\).deb\"" {} \; | cut -d'"' -f1
@@ -56,7 +56,7 @@ fetch_packages() {
   done
 
   sed -i -e 's/%2b/+/g' packages.txt
-  sort packages.txt | wget -o wget_packages.log --progress=dot:mega -P downloads -c -i -
+  sort packages.txt | wget --waitretry=100 --retry-on-http-error=429 -o wget_packages.log --progress=dot:mega -P downloads -c -i -
 }
 
 function get_version() {

--- a/debian/script.sh
+++ b/debian/script.sh
@@ -161,9 +161,11 @@ libglib2.0-0 g/glib2.0
 libglx0 libg/libglvnd
 libglx-mesa0 m/mesa
 libgtk-3-0 g/gtk+3.0
+libhwy1 h/highway
 libibus-1.0-5 i/ibus
 libice6 libi/libice
 libicu[0-9][0-9] i/icu
+libjemalloc2 j/jemalloc
 libnspr4 n/nspr
 libnss3 n/nss
 libnss-ldap libn/libnss-ldap

--- a/debian/script.sh
+++ b/debian/script.sh
@@ -153,6 +153,7 @@ libgbm1 m/mesa
 libgcc-s1 g/gcc-10
 libgcc-s1 g/gcc-11
 libgcc-s1 g/gcc-12
+libgcc-s1 g/gcc-13
 libgdk-pixbuf-2.0-0 g/gdk-pixbuf
 libgdk-pixbuf2.0-0 g/gdk-pixbuf
 libgl1-mesa-dri m/mesa
@@ -183,9 +184,10 @@ libsm6 libs/libsm
 libspa-0.2-modules p/pipewire
 libspeechd2 s/speech-dispatcher
 libsqlite3-0 s/sqlite3
-libstdc++6 g/gcc-10 libstdc++6-10
-libstdc++6 g/gcc-11 libstdc++6-11
-libstdc++6 g/gcc-12 libstdc++6-12
+libstdc++6 g/gcc-10
+libstdc++6 g/gcc-11
+libstdc++6 g/gcc-12
+libstdc++6 g/gcc-13
 libsystemd0 s/systemd
 libtcmalloc-minimal4 g/google-perftools
 libthai0 libt/libthai

--- a/fedora/script.sh
+++ b/fedora/script.sh
@@ -52,7 +52,7 @@ fetch_packages() {
     get_package_indexes ${line}
   done | sort -u > indexes.txt
 
-  wget -o wget_packages_urls.log --progress=dot:mega --compression=auto -k -i indexes.txt
+  sort indexes.txt | wget -o wget_packages_urls.log --progress=dot:mega --compression=auto -k -i indexes.txt -
 
   find . -type f -name "index.html*" | while read path; do
     mv "${path}" "${path}.bak"
@@ -62,14 +62,20 @@ fetch_packages() {
 
   echo "${1}" | while read line; do
     [ -z "${line}" ] && continue
-    get_package_urls ${line} >> packages.txt
+    get_package_urls ${line} >> unfiltered-packages.txt
+  done
+
+  touch packages.txt
+  cat unfiltered-packages.txt | while read line; do
+    package_name=$(echo "${line}" | rev | cut -d'/' -f1 | rev)
+    if ! grep -q -F "${package_name}" SHA256SUMS; then
+      echo "${line}" >> packages.txt
+    fi
   done
 
   find . -name "index.html*" -exec rm -f {} \;
 
-  wget -o wget_packages.log --progress=dot:mega -P downloads -c -i packages.txt
-
-  rev packages.txt | cut -d'/' -f1 | rev > package_names.txt
+  sort packages.txt | wget -o wget_packages.log --progress=dot:mega -P downloads -c -i -
 }
 
 function get_version() {
@@ -88,20 +94,13 @@ function find_debuginfo_package() {
 }
 
 function remove_temp_files() {
-  rm -rf symbols packages tmp symbols*.zip packages.txt package_names.txt
-}
-
-function generate_fake_packages() {
-  cat SHA256SUMS | while read line; do
-    local package_name=$(echo ${line} | cut -d',' -f1)
-    local package_size=$(echo ${line} | cut -d',' -f2)
-    truncate -s "${package_size}" "downloads/${package_name}"
-  done
+  rm -rf downloads symbols packages debug-packages tmp \
+         symbols*.zip indexes.txt packages.txt unfiltered-packages.txt \
+         crashes.list symbols.list
 }
 
 remove_temp_files
 mkdir -p downloads symbols tmp
-generate_fake_packages
 
 packages="
 alsa-lib a
@@ -194,85 +193,66 @@ xorg-x11-drv-nvidia-libs x https://mirror.nl.leaseweb.net/rpmfusion/nonfree/fedo
 
 fetch_packages "${packages}"
 
-function add_package_to_list() {
-  local package_filename=$(basename "${1}")
-  local package_size=$(stat -c"%s" "${1}")
-  printf "${package_filename},${package_size}\n" >> SHA256SUMS
-  truncate -s 0 "${1}"
-  truncate -s "${package_size}" "${1}"
-
-  if [ -n "${2}" ]; then
-    local debuginfo_package_filename=$(basename "${2}")
-    local debuginfo_package_size=$(stat -c"%s" "${2}")
-    printf "${debuginfo_package_filename},${debuginfo_package_size}\n" >> SHA256SUMS
-    truncate -s 0 "${2}"
-    truncate -s "${debuginfo_package_size}" "${2}"
-  fi
-}
-
 function process_packages() {
   local package_name="${1}"
   find downloads -name "${package_name}-[0-9]*.rpm" -type f | grep -v debuginfo | while read package; do
     local package_filename="${package##downloads/}"
-    if ! grep -q -F "${package_filename}" SHA256SUMS; then
-      local version=$(get_version "${package_name}" "${package_filename}")
-      local debuginfo_package=$(find_debuginfo_package "${package_name}" "${version}")
+    local version=$(get_version "${package_name}" "${package_filename}")
+    local debuginfo_package=$(find_debuginfo_package "${package_name}" "${version}")
 
-      truncate -s 0 error.log
+    truncate -s 0 error.log
 
-      if [ -n "${debuginfo_package}" ]; then
-        unpack_rpm_package ${package} ${debuginfo_package}
-      else
-        printf "***** Could not find debuginfo for ${package_filename}\n"
-        unpack_rpm_package ${package}
-      fi
-
-      find packages -type f | grep -v debug | while read path; do
-        if file "${path}" | grep -q ": *ELF" ; then
-          local debuginfo_path="$(find_debuginfo "${path}")"
-
-          [ -z "${debuginfo_path}" ] && printf "Could not find debuginfo for ${path}\n" && continue
-
-          local tmpfile=$(mktemp --tmpdir=tmp)
-          printf "Writing symbol file for ${path} ${debuginfo_path} ... "
-          ${DUMP_SYMS} --inlines "${path}" "${debuginfo_path}" 1> "${tmpfile}" 2> error.log
-          if [ -s "${tmpfile}" ]; then
-            printf "done\n"
-          else
-            ${DUMP_SYMS} --inlines "${path}" > "${tmpfile}"
-            if [ -s "${tmpfile}" ]; then
-              printf "done w/o debuginfo\n"
-            else
-              printf "something went terribly wrong!\n"
-            fi
-          fi
-
-          if [ -s error.log ]; then
-            printf "***** error log for package ${package} ${path} ${debuginfo_path}\n"
-            cat error.log
-            printf "***** error log for package ${package} ${path} ${debuginfo_path} ends here\n"
-          fi
-
-          # Copy the symbol file and debug information
-          debugid=$(head -n 1 "${tmpfile}" | cut -d' ' -f4)
-          filename="$(basename "${path}")"
-          mkdir -p "symbols/${filename}/${debugid}"
-          cp "${tmpfile}" "symbols/${filename}/${debugid}/${filename}.sym"
-          local soname=$(get_soname "${path}")
-          if [ -n "${soname}" ]; then
-            if [ "${soname}" != "${filename}" ]; then
-              mkdir -p "symbols/${soname}/${debugid}"
-              cp "${tmpfile}" "symbols/${soname}/${debugid}/${soname}.sym"
-            fi
-          fi
-
-          rm -f "${tmpfile}"
-        fi
-      done
-
-      rm -rf packages
-      add_package_to_list "${package}" "${debuginfo_package}"
+    if [ -n "${debuginfo_package}" ]; then
+      unpack_rpm_package ${package} ${debuginfo_package}
+    else
+      printf "***** Could not find debuginfo for ${package_filename}\n"
+      unpack_rpm_package ${package}
     fi
+
+    find packages -type f | grep -v debug | while read path; do
+      if file "${path}" | grep -q ": *ELF" ; then
+        local debuginfo_path="$(find_debuginfo "${path}")"
+
+        [ -z "${debuginfo_path}" ] && printf "Could not find debuginfo for ${path}\n" && continue
+
+        local tmpfile=$(mktemp --tmpdir=tmp)
+        printf "Writing symbol file for ${path} ${debuginfo_path} ... "
+        ${DUMP_SYMS} --inlines "${path}" "${debuginfo_path}" 1> "${tmpfile}" 2> error.log
+        if [ -s "${tmpfile}" ]; then
+          printf "done\n"
+        else
+          ${DUMP_SYMS} --inlines "${path}" > "${tmpfile}"
+          if [ -s "${tmpfile}" ]; then
+            printf "done w/o debuginfo\n"
+          else
+            printf "something went terribly wrong!\n"
+          fi
+        fi
+
+        if [ -s error.log ]; then
+          printf "***** error log for package ${package} ${path} ${debuginfo_path}\n"
+          cat error.log
+          printf "***** error log for package ${package} ${path} ${debuginfo_path} ends here\n"
+        fi
+
+        # Copy the symbol file and debug information
+        debugid=$(head -n 1 "${tmpfile}" | cut -d' ' -f4)
+        filename="$(basename "${path}")"
+        mkdir -p "symbols/${filename}/${debugid}"
+        cp "${tmpfile}" "symbols/${filename}/${debugid}/${filename}.sym"
+        local soname=$(get_soname "${path}")
+        if [ -n "${soname}" ]; then
+          if [ "${soname}" != "${filename}" ]; then
+            mkdir -p "symbols/${soname}/${debugid}"
+            cp "${tmpfile}" "symbols/${soname}/${debugid}/${soname}.sym"
+          fi
+        fi
+
+        rm -f "${tmpfile}"
+      fi
+    done
+
+    rm -rf packages
   done
 }
 
@@ -286,5 +266,7 @@ zip_symbols
 upload_symbols
 
 reprocess_crashes
+
+update_sha256sums
 
 remove_temp_files

--- a/fedora/script.sh
+++ b/fedora/script.sh
@@ -52,7 +52,7 @@ fetch_packages() {
     get_package_indexes ${line}
   done | sort -u > indexes.txt
 
-  sort indexes.txt | wget -o wget_packages_urls.log --progress=dot:mega --compression=auto -k -i indexes.txt -
+  sort indexes.txt | wget --waitretry=100 --retry-on-http-error=429 -o wget_packages_urls.log --progress=dot:mega --compression=auto -k -i -
 
   find . -type f -name "index.html*" | while read path; do
     mv "${path}" "${path}.bak"
@@ -75,7 +75,7 @@ fetch_packages() {
 
   find . -name "index.html*" -exec rm -f {} \;
 
-  sort packages.txt | wget -o wget_packages.log --progress=dot:mega -P downloads -c -i -
+  sort packages.txt | wget --waitretry=100 --retry-on-http-error=429 -o wget_packages.log --progress=dot:mega -P downloads -c -i -
 }
 
 function get_version() {

--- a/fedora/script.sh
+++ b/fedora/script.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+export DEBUGINFOD_URLS="https://debuginfod.fedoraproject.org/"
+
 . $(dirname $0)/../common.sh
 
 URL="https://fedora.mirror.wearetriple.com/linux"

--- a/fedora/script.sh
+++ b/fedora/script.sh
@@ -52,7 +52,7 @@ fetch_packages() {
     get_package_indexes ${line}
   done | sort -u > indexes.txt
 
-  sort indexes.txt | wget --waitretry=100 --retry-on-http-error=429 -o wget_packages_urls.log --progress=dot:mega --compression=auto -k -i -
+  sort indexes.txt | ${WGET} -o wget_packages_urls.log -k -i -
 
   find . -type f -name "index.html*" | while read path; do
     mv "${path}" "${path}.bak"
@@ -75,7 +75,7 @@ fetch_packages() {
 
   find . -name "index.html*" -exec rm -f {} \;
 
-  sort packages.txt | wget --waitretry=100 --retry-on-http-error=429 -o wget_packages.log --progress=dot:mega -P downloads -c -i -
+  sort packages.txt | ${WGET} -o wget_packages.log -P downloads -c -i -
 }
 
 function get_version() {

--- a/fedora/script.sh
+++ b/fedora/script.sh
@@ -261,7 +261,7 @@ echo "${packages}" | while read line; do
   process_packages ${line}
 done
 
-zip_symbols
+create_symbols_archive
 
 upload_symbols
 

--- a/fedora/script.sh
+++ b/fedora/script.sh
@@ -160,6 +160,7 @@ libXext l
 libxkbcommon l
 libxml2 l
 llvm-libs l
+llvm[0-9][0-9]-libs l
 mesa-dri-drivers m
 mesa-libEGL m
 mesa-libgbm m

--- a/fedora/script.sh
+++ b/fedora/script.sh
@@ -128,9 +128,11 @@ glib-networking g
 gnome-vfs2 g
 gtk2 g
 gtk3 g
+highway h
 ibus-libs i
 intel-gmmlib i
 intel-media-driver i https://mirror.nl.leaseweb.net/rpmfusion/nonfree/fedora
+jemalloc j
 libdrm l
 libepoxy l
 libevent l

--- a/fedora/script.sh
+++ b/fedora/script.sh
@@ -95,7 +95,7 @@ function generate_fake_packages() {
   cat SHA256SUMS | while read line; do
     local package_name=$(echo ${line} | cut -d',' -f1)
     local package_size=$(echo ${line} | cut -d',' -f2)
-    truncate --size "${package_size}" "downloads/${package_name}"
+    truncate -s "${package_size}" "downloads/${package_name}"
   done
 }
 
@@ -198,15 +198,15 @@ function add_package_to_list() {
   local package_filename=$(basename "${1}")
   local package_size=$(stat -c"%s" "${1}")
   printf "${package_filename},${package_size}\n" >> SHA256SUMS
-  truncate --size 0 "${1}"
-  truncate --size "${package_size}" "${1}"
+  truncate -s 0 "${1}"
+  truncate -s "${package_size}" "${1}"
 
   if [ -n "${2}" ]; then
     local debuginfo_package_filename=$(basename "${2}")
     local debuginfo_package_size=$(stat -c"%s" "${2}")
     printf "${debuginfo_package_filename},${debuginfo_package_size}\n" >> SHA256SUMS
-    truncate --size 0 "${2}"
-    truncate --size "${debuginfo_package_size}" "${2}"
+    truncate -s 0 "${2}"
+    truncate -s "${debuginfo_package_size}" "${2}"
   fi
 }
 
@@ -218,7 +218,7 @@ function process_packages() {
       local version=$(get_version "${package_name}" "${package_filename}")
       local debuginfo_package=$(find_debuginfo_package "${package_name}" "${version}")
 
-      truncate --size=0 error.log
+      truncate -s 0 error.log
 
       if [ -n "${debuginfo_package}" ]; then
         unpack_rpm_package ${package} ${debuginfo_package}

--- a/fedora/script.sh
+++ b/fedora/script.sh
@@ -202,8 +202,6 @@ function process_packages() {
     local version=$(get_version "${package_name}" "${package_filename}")
     local debuginfo_package=$(find_debuginfo_package "${package_name}" "${version}")
 
-    truncate -s 0 error.log
-
     if [ -n "${debuginfo_package}" ]; then
       unpack_rpm_package ${package} ${debuginfo_package}
     else
@@ -215,20 +213,21 @@ function process_packages() {
       if file "${path}" | grep -q ": *ELF" ; then
         local debuginfo_path="$(find_debuginfo "${path}")"
 
-        [ -z "${debuginfo_path}" ] && printf "Could not find debuginfo for ${path}\n" && continue
-
+        truncate -s 0 error.log
         local tmpfile=$(mktemp --tmpdir=tmp)
         printf "Writing symbol file for ${path} ${debuginfo_path} ... "
-        ${DUMP_SYMS} --inlines "${path}" "${debuginfo_path}" 1> "${tmpfile}" 2> error.log
-        if [ -s "${tmpfile}" ]; then
+        if [ -n "${debuginfo_path}" ]; then
+          ${DUMP_SYMS} --inlines "${path}" "${debuginfo_path}" 1> "${tmpfile}" 2> error.log
+        else
+          ${DUMP_SYMS} --inlines "${path}" 1> "${tmpfile}" 2> error.log
+        fi
+
+        if [ -s "${tmpfile}" -a -z "${debuginfo_path}" ]; then
+          printf "done w/o debuginfo\n"
+        elif [ -s "${tmpfile}" ]; then
           printf "done\n"
         else
-          ${DUMP_SYMS} --inlines "${path}" > "${tmpfile}"
-          if [ -s "${tmpfile}" ]; then
-            printf "done w/o debuginfo\n"
-          else
-            printf "something went terribly wrong!\n"
-          fi
+          printf "something went terribly wrong!\n"
         fi
 
         if [ -s error.log ]; then

--- a/firefox-flatpak/script.sh
+++ b/firefox-flatpak/script.sh
@@ -8,7 +8,7 @@ process_flatpak \
 	"org.freedesktop.Platform.GL.Debug.default/x86_64/22.08" \
 	"org.freedesktop.Platform.GL.Debug.default/x86_64/22.08-extra"
 
-zip_symbols
+create_symbols_archive
 
 upload_symbols
 

--- a/firefox-snap/script.sh
+++ b/firefox-snap/script.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+export DEBUGINFOD_URLS="https://debuginfod.ubuntu.com/"
+
 . $(dirname $0)/../common.sh
 . $(dirname $0)/../launchpad.sh
 

--- a/firefox-snap/script.sh
+++ b/firefox-snap/script.sh
@@ -13,7 +13,7 @@ process_snap "firefox-snap-beta" "firefox" "mozilla-snaps"
 process_snap "firefox-snap-core22" "firefox" "mozilla-snaps"
 process_snap "firefox-snap-nightly" "firefox" "mozilla-snaps"
 
-zip_symbols
+create_symbols_archive
 
 upload_symbols
 

--- a/gnome-sdk-snap/script.sh
+++ b/gnome-sdk-snap/script.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+export DEBUGINFOD_URLS="https://debuginfod.ubuntu.com/"
+
 . $(dirname $0)/../common.sh
 . $(dirname $0)/../launchpad.sh
 

--- a/gnome-sdk-snap/script.sh
+++ b/gnome-sdk-snap/script.sh
@@ -8,7 +8,7 @@ export DEBUGINFOD_URLS="https://debuginfod.ubuntu.com/"
 process_snap "gnome-3-38-2004-sdk" "gnome-3-38-2004-sdk" "desktop-snappers"
 process_snap "gnome-42-2204-sdk" "gnome-42-2204-sdk" "desktop-snappers"
 
-zip_symbols
+create_symbols_archive
 
 upload_symbols
 

--- a/opensuse/script.sh
+++ b/opensuse/script.sh
@@ -119,7 +119,7 @@ function generate_fake_packages() {
   cat SHA256SUMS | while read line; do
     local package_name=$(echo ${line} | cut -d',' -f1)
     local package_size=$(echo ${line} | cut -d',' -f2)
-    truncate --size "${package_size}" "downloads/${package_name}"
+    truncate -s "${package_size}" "downloads/${package_name}"
   done
 }
 
@@ -242,15 +242,15 @@ function add_package_to_list() {
   local package_filename=$(basename "${1}")
   local package_size=$(stat -c"%s" "${1}")
   printf "${package_filename},${package_size}\n" >> SHA256SUMS
-  truncate --size 0 "${1}"
-  truncate --size "${package_size}" "${1}"
+  truncate -s 0 "${1}"
+  truncate -s "${package_size}" "${1}"
 
   if [ -n "${2}" ]; then
     local debuginfo_package_filename=$(basename "${2}")
     local debuginfo_package_size=$(stat -c"%s" "${2}")
     printf "${debuginfo_package_filename},${debuginfo_package_size}\n" >> SHA256SUMS
-    truncate --size 0 "${2}"
-    truncate --size "${debuginfo_package_size}" "${2}"
+    truncate -s 0 "${2}"
+    truncate -s "${debuginfo_package_size}" "${2}"
   fi
 }
 
@@ -262,7 +262,7 @@ function process_packages() {
       local version=$(get_version "${package_name}" "${package_filename}")
       local debuginfo_package=$(find_debuginfo_package "${package_name}" "${version}")
 
-      truncate --size=0 error.log
+      truncate -s 0 error.log
 
       if [ -n "${debuginfo_package}" ]; then
         unpack_rpm_package ${package} ${debuginfo_package}

--- a/opensuse/script.sh
+++ b/opensuse/script.sh
@@ -76,7 +76,7 @@ get_package_indexes() {
 fetch_packages() {
   get_package_indexes
 
-  sort indexes.txt | wget --waitretry=100 --retry-on-http-error=429 -o wget_packages_urls.log --progress=dot:mega --compression=auto -k -i -
+  sort indexes.txt | ${WGET} -o wget_packages_urls.log -k -i -
 
   find . -name "index.html*" | while read path; do
     mv "${path}" "${path}.bak"
@@ -99,7 +99,7 @@ fetch_packages() {
 
   find . -name "index.html*" -exec rm -f {} \;
 
-  sort packages.txt | wget --waitretry=100 --retry-on-http-error=429 -o wget_packages.log --progress=dot:mega -P downloads -c -i -
+  sort packages.txt | ${WGET} -o wget_packages.log -P downloads -c -i -
 }
 
 function get_version() {

--- a/opensuse/script.sh
+++ b/opensuse/script.sh
@@ -305,7 +305,7 @@ echo "${packages}" | while read line; do
   process_packages ${line}
 done
 
-zip_symbols
+create_symbols_archive
 
 upload_symbols
 

--- a/opensuse/script.sh
+++ b/opensuse/script.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+export DEBUGINFOD_URLS="https://debuginfod.opensuse.org/"
+
 . $(dirname $0)/../common.sh
 
 URL="https://download.opensuse.org"

--- a/opensuse/script.sh
+++ b/opensuse/script.sh
@@ -76,7 +76,7 @@ get_package_indexes() {
 fetch_packages() {
   get_package_indexes
 
-  sort indexes.txt | wget -o wget_packages_urls.log --progress=dot:mega --compression=auto -k -i -
+  sort indexes.txt | wget --waitretry=100 --retry-on-http-error=429 -o wget_packages_urls.log --progress=dot:mega --compression=auto -k -i -
 
   find . -name "index.html*" | while read path; do
     mv "${path}" "${path}.bak"
@@ -99,7 +99,7 @@ fetch_packages() {
 
   find . -name "index.html*" -exec rm -f {} \;
 
-  sort packages.txt | wget -o wget_packages.log --progress=dot:mega -P downloads -c -i -
+  sort packages.txt | wget --waitretry=100 --retry-on-http-error=429 -o wget_packages.log --progress=dot:mega -P downloads -c -i -
 }
 
 function get_version() {

--- a/opensuse/script.sh
+++ b/opensuse/script.sh
@@ -76,7 +76,7 @@ get_package_indexes() {
 fetch_packages() {
   get_package_indexes
 
-  wget -o wget_packages_urls.log --progress=dot:mega --compression=auto -k -i indexes.txt
+  sort indexes.txt | wget -o wget_packages_urls.log --progress=dot:mega --compression=auto -k -i -
 
   find . -name "index.html*" | while read path; do
     mv "${path}" "${path}.bak"
@@ -86,14 +86,20 @@ fetch_packages() {
 
   echo "${1}" | while read line; do
     [ -z "${line}" ] && continue
-    get_package_urls ${line} >> packages.txt
+    get_package_urls ${line} >> unfiltered-packages.txt
+  done
+
+  touch packages.txt
+  cat unfiltered-packages.txt | while read line; do
+    package_name=$(echo "${line}" | rev | cut -d'/' -f1 | rev)
+    if ! grep -q -F "${package_name}" SHA256SUMS; then
+      echo "${line}" >> packages.txt
+    fi
   done
 
   find . -name "index.html*" -exec rm -f {} \;
 
-  wget -o wget_packages.log --progress=dot:mega -P downloads -c -i packages.txt
-
-  rev packages.txt | cut -d'/' -f1 | rev > package_names.txt
+  sort packages.txt | wget -o wget_packages.log --progress=dot:mega -P downloads -c -i -
 }
 
 function get_version() {
@@ -112,20 +118,13 @@ function find_debuginfo_package() {
 }
 
 function remove_temp_files() {
-  rm -rf symbols packages tmp symbols*.zip packages.txt package_names.txt
-}
-
-function generate_fake_packages() {
-  cat SHA256SUMS | while read line; do
-    local package_name=$(echo ${line} | cut -d',' -f1)
-    local package_size=$(echo ${line} | cut -d',' -f2)
-    truncate -s "${package_size}" "downloads/${package_name}"
-  done
+  rm -rf downloads symbols packages debug-packages tmp \
+         symbols*.zip indexes.txt packages.txt unfiltered-packages.txt \
+         crashes.list symbols.list
 }
 
 remove_temp_files
 mkdir -p downloads symbols tmp
-generate_fake_packages
 
 packages="
 alsa
@@ -238,85 +237,66 @@ x11-video-nvidiaG[0-9][0-9]
 
 fetch_packages "${packages}"
 
-function add_package_to_list() {
-  local package_filename=$(basename "${1}")
-  local package_size=$(stat -c"%s" "${1}")
-  printf "${package_filename},${package_size}\n" >> SHA256SUMS
-  truncate -s 0 "${1}"
-  truncate -s "${package_size}" "${1}"
-
-  if [ -n "${2}" ]; then
-    local debuginfo_package_filename=$(basename "${2}")
-    local debuginfo_package_size=$(stat -c"%s" "${2}")
-    printf "${debuginfo_package_filename},${debuginfo_package_size}\n" >> SHA256SUMS
-    truncate -s 0 "${2}"
-    truncate -s "${debuginfo_package_size}" "${2}"
-  fi
-}
-
 function process_packages() {
   local package_name="${1}"
   find downloads -name "${package_name}-[0-9]*.rpm" -type f | grep -v debuginfo | while read package; do
     local package_filename="${package##downloads/}"
-    if ! grep -q -F "${package_filename}" SHA256SUMS; then
-      local version=$(get_version "${package_name}" "${package_filename}")
-      local debuginfo_package=$(find_debuginfo_package "${package_name}" "${version}")
+    local version=$(get_version "${package_name}" "${package_filename}")
+    local debuginfo_package=$(find_debuginfo_package "${package_name}" "${version}")
 
-      truncate -s 0 error.log
+    truncate -s 0 error.log
 
-      if [ -n "${debuginfo_package}" ]; then
-        unpack_rpm_package ${package} ${debuginfo_package}
-      else
-        printf "***** Could not find debuginfo for ${package_filename}\n"
-        unpack_rpm_package ${package}
-      fi
-
-      find packages -type f | grep -v debug | while read path; do
-        if file "${path}" | grep -q ": *ELF" ; then
-          local debuginfo_path="$(find_debuginfo "${path}" "${version}")"
-
-          [ -z "${debuginfo_path}" ] && printf "Could not find debuginfo for ${path}\n" && continue
-
-          local tmpfile=$(mktemp --tmpdir=tmp)
-          printf "Writing symbol file for ${path} ${debuginfo_path} ... "
-          ${DUMP_SYMS} --inlines "${path}" "${debuginfo_path}" 1> "${tmpfile}" 2> error.log
-          if [ -s "${tmpfile}" ]; then
-            printf "done\n"
-          else
-            ${DUMP_SYMS} --inlines "${path}" > "${tmpfile}"
-            if [ -s "${tmpfile}" ]; then
-              printf "done w/o debuginfo\n"
-            else
-              printf "something went terribly wrong!\n"
-            fi
-          fi
-
-          if [ -s error.log ]; then
-            printf "***** error log for package ${package} ${path} ${debuginfo_path}\n"
-            cat error.log
-            printf "***** error log for package ${package} ${path} ${debuginfo_path} ends here\n"
-          fi
-
-          # Copy the symbol file and debug information
-          debugid=$(head -n 1 "${tmpfile}" | cut -d' ' -f4)
-          filename="$(basename "${path}")"
-          mkdir -p "symbols/${filename}/${debugid}"
-          cp "${tmpfile}" "symbols/${filename}/${debugid}/${filename}.sym"
-          local soname=$(get_soname "${path}")
-          if [ -n "${soname}" ]; then
-            if [ "${soname}" != "${filename}" ]; then
-              mkdir -p "symbols/${soname}/${debugid}"
-              cp "${tmpfile}" "symbols/${soname}/${debugid}/${soname}.sym"
-            fi
-          fi
-
-          rm -f "${tmpfile}"
-        fi
-      done
-
-      rm -rf packages
-      add_package_to_list "${package}" "${debuginfo_package}"
+    if [ -n "${debuginfo_package}" ]; then
+      unpack_rpm_package ${package} ${debuginfo_package}
+    else
+      printf "***** Could not find debuginfo for ${package_filename}\n"
+      unpack_rpm_package ${package}
     fi
+
+    find packages -type f | grep -v debug | while read path; do
+      if file "${path}" | grep -q ": *ELF" ; then
+        local debuginfo_path="$(find_debuginfo "${path}" "${version}")"
+
+        [ -z "${debuginfo_path}" ] && printf "Could not find debuginfo for ${path}\n" && continue
+
+        local tmpfile=$(mktemp --tmpdir=tmp)
+        printf "Writing symbol file for ${path} ${debuginfo_path} ... "
+        ${DUMP_SYMS} --inlines "${path}" "${debuginfo_path}" 1> "${tmpfile}" 2> error.log
+        if [ -s "${tmpfile}" ]; then
+          printf "done\n"
+        else
+          ${DUMP_SYMS} --inlines "${path}" > "${tmpfile}"
+          if [ -s "${tmpfile}" ]; then
+            printf "done w/o debuginfo\n"
+          else
+            printf "something went terribly wrong!\n"
+          fi
+        fi
+
+        if [ -s error.log ]; then
+          printf "***** error log for package ${package} ${path} ${debuginfo_path}\n"
+          cat error.log
+          printf "***** error log for package ${package} ${path} ${debuginfo_path} ends here\n"
+        fi
+
+        # Copy the symbol file and debug information
+        debugid=$(head -n 1 "${tmpfile}" | cut -d' ' -f4)
+        filename="$(basename "${path}")"
+        mkdir -p "symbols/${filename}/${debugid}"
+        cp "${tmpfile}" "symbols/${filename}/${debugid}/${filename}.sym"
+        local soname=$(get_soname "${path}")
+        if [ -n "${soname}" ]; then
+          if [ "${soname}" != "${filename}" ]; then
+            mkdir -p "symbols/${soname}/${debugid}"
+            cp "${tmpfile}" "symbols/${soname}/${debugid}/${soname}.sym"
+          fi
+        fi
+
+        rm -f "${tmpfile}"
+      fi
+    done
+
+    rm -rf packages
   done
 }
 
@@ -330,5 +310,7 @@ zip_symbols
 upload_symbols
 
 reprocess_crashes
+
+update_sha256sums
 
 remove_temp_files

--- a/opensuse/script.sh
+++ b/opensuse/script.sh
@@ -174,10 +174,12 @@ libglvnd
 libgobject-2_0-0
 libgtk-2_0-0
 libgtk-3-0
+libhwy1
 libibus-1_0-5
 libICE6
 libicu[0-9][0-9]
 libigdgmm12
+libjemalloc2
 libnuma1
 libopus0
 libpango-1_0-0

--- a/ubuntu/script.sh
+++ b/ubuntu/script.sh
@@ -22,13 +22,23 @@ get_package_urls() {
   local urls="${url}/${main_path}/ ${url}/${universe_path}/ ${url}/${multiverse_path} ${ddeb_url}/${main_path}/ ${ddeb_url}/${universe_path}/ ${ddeb_url}/${multiverse_path}/"
 
   if [ -n "${alt_url}" ]; then
-    urls="${urls} ${alt_url}/${main_path}/ ${alt_url}/${universe_path}/"
+    urls="${urls} ${alt_url}/${main_path}/ ${alt_url}/${universe_path}/ ${alt_url}/${multiverse_path}/"
   fi
 
   wget -o wget_packages_urls.log --progress=dot:mega -k ${urls}
-  for i in ${urls}; do
-    find . -name "index.html*" -exec grep -o "${i}\(${package_name}\|${dbg_package_name}-dbg\|${dbgsym_package_name}-dbgsym\)_.*_\(i386\|amd64\).d.*eb\"" {} \; | cut -d'"' -f1
-  done
+  find . -name "index.html*" -exec grep -o "${url}/${main_path}/\(${package_name}\|${dbg_package_name}-dbg\|${dbgsym_package_name}-dbgsym\)_.*_\(i386\|amd64\).d.*eb\"" {} \; | cut -d'"' -f1
+  find . -name "index.html*" -exec grep -o "${url}/${universe_path}/\(${package_name}\|${dbg_package_name}-dbg\|${dbgsym_package_name}-dbgsym\)_.*_\(i386\|amd64\).d.*eb\"" {} \; | cut -d'"' -f1
+  find . -name "index.html*" -exec grep -o "${url}/${multiverse_path}/\(${package_name}\|${dbg_package_name}-dbg\|${dbgsym_package_name}-dbgsym\)_.*_\(i386\|amd64\).d.*eb\"" {} \; | cut -d'"' -f1
+  find . -name "index.html*" -exec grep -o "${ddeb_url}/${main_path}/\(${package_name}\|${dbg_package_name}-dbg\|${dbgsym_package_name}-dbgsym\)_.*_\(i386\|amd64\).d.*eb\"" {} \; | cut -d'"' -f1
+  find . -name "index.html*" -exec grep -o "${ddeb_url}/${universe_path}/\(${package_name}\|${dbg_package_name}-dbg\|${dbgsym_package_name}-dbgsym\)_.*_\(i386\|amd64\).d.*eb\"" {} \; | cut -d'"' -f1
+  find . -name "index.html*" -exec grep -o "${ddeb_url}/${multiverse_path}/\(${package_name}\|${dbg_package_name}-dbg\|${dbgsym_package_name}-dbgsym\)_.*_\(i386\|amd64\).d.*eb\"" {} \; | cut -d'"' -f1
+
+  if [ -n "${alt_url}" ]; then
+    find . -name "index.html*" -exec grep -o "${alt_url}/${main_path}/\(${package_name}\|${dbg_package_name}-dbg\|${dbgsym_package_name}-dbgsym\)_.*_\(i386\|amd64\).d.*eb\"" {} \; | cut -d'"' -f1
+    find . -name "index.html*" -exec grep -o "${alt_url}/${universe_path}/\(${package_name}\|${dbg_package_name}-dbg\|${dbgsym_package_name}-dbgsym\)_.*_\(i386\|amd64\).d.*eb\"" {} \; | cut -d'"' -f1
+    find . -name "index.html*" -exec grep -o "${alt_url}/${multiverse_path}/\(${package_name}\|${dbg_package_name}-dbg\|${dbgsym_package_name}-dbgsym\)_.*_\(i386\|amd64\).d.*eb\"" {} \; | cut -d'"' -f1
+  fi
+
   find . -name "index.html*" -exec rm -f {} \;
 }
 

--- a/ubuntu/script.sh
+++ b/ubuntu/script.sh
@@ -154,6 +154,7 @@ libgbm1 m/mesa
 libgcc-s1 g/gcc-10
 libgcc-s1 g/gcc-11
 libgcc-s1 g/gcc-12
+libgcc-s1 g/gcc-13
 libgdk-pixbuf-2.0-0 g/gdk-pixbuf
 libgdk-pixbuf2.0-0 g/gdk-pixbuf
 libgl1-mesa-dri m/mesa
@@ -184,9 +185,10 @@ libsm6 libs/libsm
 libspa-0.2-modules p/pipewire
 libspeechd2 s/speech-dispatcher
 libsqlite3-0 s/sqlite3
-libstdc++6 g/gcc-10 libstdc++6-10
-libstdc++6 g/gcc-11 libstdc++6-11
-libstdc++6 g/gcc-12 libstdc++6-12
+libstdc++6 g/gcc-10
+libstdc++6 g/gcc-11
+libstdc++6 g/gcc-12
+libstdc++6 g/gcc-13
 libsystemd0 s/systemd
 libtcmalloc-minimal4 g/google-perftools
 libthai0 libt/libthai

--- a/ubuntu/script.sh
+++ b/ubuntu/script.sh
@@ -45,12 +45,19 @@ get_package_urls() {
 fetch_packages() {
   echo "${1}" | while read line; do
     [ -z "${line}" ] && continue
-    get_package_urls ${line} >> packages.txt
+    get_package_urls ${line} >> unfiltered-packages.txt
+  done
+
+  touch packages.txt
+  cat unfiltered-packages.txt | while read line; do
+    package_name=$(echo "${line}" | rev | cut -d'/' -f1 | rev)
+    if ! grep -q -F "${package_name}" SHA256SUMS; then
+      echo "${line}" >> packages.txt
+    fi
   done
 
   sed -i -e 's/%2b/+/g' packages.txt
   sort packages.txt | wget -o wget_packages.log --progress=dot:mega -P downloads -c -i -
-  rev packages.txt | cut -d'/' -f1 | rev > package_names.txt
 }
 
 function get_version() {
@@ -96,20 +103,13 @@ function unpack_package() {
 }
 
 function remove_temp_files() {
-  rm -rf symbols packages tmp symbols*.zip packages.txt package_names.txt
-}
-
-function generate_fake_packages() {
-  cat SHA256SUMS | while read line; do
-    local package_name=$(echo ${line} | cut -d',' -f1)
-    local package_size=$(echo ${line} | cut -d',' -f2)
-    truncate -s "${package_size}" "downloads/${package_name}"
-  done
+  rm -rf downloads symbols packages debug-packages tmp \
+         symbols*.zip indexes.txt packages.txt unfiltered-packages.txt \
+         crashes.list symbols.list
 }
 
 remove_temp_files
 mkdir -p downloads symbols tmp
-generate_fake_packages
 
 packages="
 apitrace-tracers a/apitrace
@@ -215,88 +215,69 @@ zlib1g z/zlib
 
 fetch_packages "${packages}"
 
-function add_package_to_list() {
-  local package_filename=$(basename "${1}")
-  local package_size=$(stat -c"%s" "${1}")
-  printf "${package_filename},${package_size}\n" >> SHA256SUMS
-  truncate -s 0 "${1}"
-  truncate -s "${package_size}" "${1}"
-
-  if [ -n "${2}" ]; then
-    local debuginfo_package_filename=$(basename "${2}")
-    local debuginfo_package_size=$(stat -c"%s" "${2}")
-    printf "${debuginfo_package_filename},${debuginfo_package_size}\n" >> SHA256SUMS
-    truncate -s 0 "${2}"
-    truncate -s "${debuginfo_package_size}" "${2}"
-  fi
-}
-
 function process_packages() {
   local package_name="${1}"
   for arch in i386 amd64; do
     find downloads -name "${package_name}_[0-9]*_${arch}.deb" -type f | grep -v dbg | while read package; do
       local package_filename="${package##downloads/}"
-      if ! grep -q -F "${package_filename}" SHA256SUMS; then
-        local version=$(get_version "${package_name}" "${package_filename}")
-        local debug_package_name="${3:-$package_name}"
-        printf "package_name = ${package_name} version = ${version} dbg_package_name = ${debug_package_name}\n"
-        local debuginfo_package=$(find_debuginfo_package "${package_name}" "${version}" "${debug_package_name}")
+      local version=$(get_version "${package_name}" "${package_filename}")
+      local debug_package_name="${3:-$package_name}"
+      printf "package_name = ${package_name} version = ${version} dbg_package_name = ${debug_package_name}\n"
+      local debuginfo_package=$(find_debuginfo_package "${package_name}" "${version}" "${debug_package_name}")
 
-        truncate -s 0 error.log
+      truncate -s 0 error.log
 
-        if [ -n "${debuginfo_package}" ]; then
-          unpack_package ${package} ${debuginfo_package}
-        else
-          printf "***** Could not find debuginfo for ${package_filename}\n"
-          unpack_package ${package}
-        fi
-
-        find packages -type f | grep -v debug | while read path; do
-          if file "${path}" | grep -q ": *ELF" ; then
-            local debuginfo_path="$(find_debuginfo "${path}")"
-
-            [ -z "${debuginfo_path}" ] && printf "Could not find debuginfo for ${path}\n" && continue
-
-            local tmpfile=$(mktemp --tmpdir=tmp)
-            printf "Writing symbol file for ${path} ${debuginfo_path} ... "
-            ${DUMP_SYMS} --inlines "${path}" "${debuginfo_path}" 1> "${tmpfile}" 2>>error.log
-            if [ -s "${tmpfile}" ]; then
-              printf "done\n"
-            else
-              ${DUMP_SYMS} --inlines "${path}" > "${tmpfile}"
-              if [ -s "${tmpfile}" ]; then
-                printf "done w/o debuginfo\n"
-              else
-                printf "something went terribly wrong!\n"
-              fi
-            fi
-
-            # Copy the symbol file and debug information
-            debugid=$(head -n 1 "${tmpfile}" | cut -d' ' -f4)
-            filename="$(basename "${path}")"
-            mkdir -p "symbols/${filename}/${debugid}"
-            cp "${tmpfile}" "symbols/${filename}/${debugid}/${filename}.sym"
-            local soname=$(get_soname "${path}")
-            if [ -n "${soname}" ]; then
-              if [ "${soname}" != "${filename}" ]; then
-                mkdir -p "symbols/${soname}/${debugid}"
-                cp "${tmpfile}" "symbols/${soname}/${debugid}/${soname}.sym"
-              fi
-            fi
-
-            rm -f "${tmpfile}"
-          fi
-        done
-
-        if [ -s error.log ]; then
-          printf "***** error log for package ${package}\n"
-          cat error.log
-          printf "***** error log for package ${package} ends here\n"
-        fi
-
-        rm -rf packages
-        add_package_to_list "${package}" "${debuginfo_package}"
+      if [ -n "${debuginfo_package}" ]; then
+        unpack_package ${package} ${debuginfo_package}
+      else
+        printf "***** Could not find debuginfo for ${package_filename}\n"
+        unpack_package ${package}
       fi
+
+      find packages -type f | grep -v debug | while read path; do
+        if file "${path}" | grep -q ": *ELF" ; then
+          local debuginfo_path="$(find_debuginfo "${path}")"
+
+          [ -z "${debuginfo_path}" ] && printf "Could not find debuginfo for ${path}\n" && continue
+
+          local tmpfile=$(mktemp --tmpdir=tmp)
+          printf "Writing symbol file for ${path} ${debuginfo_path} ... "
+          ${DUMP_SYMS} --inlines "${path}" "${debuginfo_path}" 1> "${tmpfile}" 2>>error.log
+          if [ -s "${tmpfile}" ]; then
+            printf "done\n"
+          else
+            ${DUMP_SYMS} --inlines "${path}" > "${tmpfile}"
+            if [ -s "${tmpfile}" ]; then
+              printf "done w/o debuginfo\n"
+            else
+              printf "something went terribly wrong!\n"
+            fi
+          fi
+
+          # Copy the symbol file and debug information
+          debugid=$(head -n 1 "${tmpfile}" | cut -d' ' -f4)
+          filename="$(basename "${path}")"
+          mkdir -p "symbols/${filename}/${debugid}"
+          cp "${tmpfile}" "symbols/${filename}/${debugid}/${filename}.sym"
+          local soname=$(get_soname "${path}")
+          if [ -n "${soname}" ]; then
+            if [ "${soname}" != "${filename}" ]; then
+              mkdir -p "symbols/${soname}/${debugid}"
+              cp "${tmpfile}" "symbols/${soname}/${debugid}/${soname}.sym"
+            fi
+          fi
+
+          rm -f "${tmpfile}"
+        fi
+      done
+
+      if [ -s error.log ]; then
+        printf "***** error log for package ${package}\n"
+        cat error.log
+        printf "***** error log for package ${package} ends here\n"
+      fi
+
+      rm -rf packages
     done
   done
 }
@@ -311,5 +292,7 @@ zip_symbols
 upload_symbols
 
 reprocess_crashes
+
+update_sha256sums
 
 remove_temp_files

--- a/ubuntu/script.sh
+++ b/ubuntu/script.sh
@@ -287,7 +287,7 @@ echo "${packages}" | while read line; do
   process_packages ${line}
 done
 
-zip_symbols
+create_symbols_archive
 
 upload_symbols
 

--- a/ubuntu/script.sh
+++ b/ubuntu/script.sh
@@ -78,20 +78,20 @@ function unpack_package() {
   local debug_package_name="${2}"
   mkdir packages
   data_file=$(ar t "${package_name}" | grep ^data)
-  ar x "${package_name}" && \
+  ar x "${package_name}" "${data_file}" && \
   tar -C packages -x -a -f "${data_file}"
   if [ $? -ne 0 ]; then
     printf "Failed to extract ${package_name}\n" 2>>error.log
   fi
-  rm -f data.tar* control.tar* debian-binary
+  rm -f "${data_file}"
   if [ -n "${debug_package_name}" ]; then
     data_file=$(ar t "${package_name}" | grep ^data)
-    ar x "${debug_package_name}" && \
+    ar x "${debug_package_name}" "${data_file}" && \
     tar -C packages -x -a -f "${data_file}"
     if [ $? -ne 0 ]; then
       printf "Failed to extract ${debug_package_name}\n" 2>>error.log
     fi
-    rm -f data.tar* control.tar* debian-binary
+    rm -f "${data_file}"
   fi
 }
 

--- a/ubuntu/script.sh
+++ b/ubuntu/script.sh
@@ -162,9 +162,11 @@ libglib2.0-0 g/glib2.0
 libglx0 libg/libglvnd
 libglx-mesa0 m/mesa
 libgtk-3-0 g/gtk+3.0
+libhwy1 h/highway
 libibus-1.0-5 i/ibus
 libice6 libi/libice
 libicu[0-9][0-9] i/icu
+libjemalloc2 j/jemalloc
 libnspr4 n/nspr
 libnss3 n/nss
 libnss-ldap libn/libnss-ldap

--- a/ubuntu/script.sh
+++ b/ubuntu/script.sh
@@ -25,7 +25,7 @@ get_package_urls() {
     urls="${urls} ${alt_url}/${main_path}/ ${alt_url}/${universe_path}/ ${alt_url}/${multiverse_path}/"
   fi
 
-  wget -o wget_packages_urls.log --progress=dot:mega -k ${urls}
+  wget --waitretry=100 --retry-on-http-error=429 -o wget_packages_urls.log --progress=dot:mega -k ${urls}
   find . -name "index.html*" -exec grep -o "${url}/${main_path}/\(${package_name}\|${dbg_package_name}-dbg\|${dbgsym_package_name}-dbgsym\)_.*_\(i386\|amd64\).d.*eb\"" {} \; | cut -d'"' -f1
   find . -name "index.html*" -exec grep -o "${url}/${universe_path}/\(${package_name}\|${dbg_package_name}-dbg\|${dbgsym_package_name}-dbgsym\)_.*_\(i386\|amd64\).d.*eb\"" {} \; | cut -d'"' -f1
   find . -name "index.html*" -exec grep -o "${url}/${multiverse_path}/\(${package_name}\|${dbg_package_name}-dbg\|${dbgsym_package_name}-dbgsym\)_.*_\(i386\|amd64\).d.*eb\"" {} \; | cut -d'"' -f1
@@ -57,7 +57,7 @@ fetch_packages() {
   done
 
   sed -i -e 's/%2b/+/g' packages.txt
-  sort packages.txt | wget -o wget_packages.log --progress=dot:mega -P downloads -c -i -
+  sort packages.txt | wget --waitretry=100 --retry-on-http-error=429 -o wget_packages.log --progress=dot:mega -P downloads -c -i -
 }
 
 function get_version() {

--- a/ubuntu/script.sh
+++ b/ubuntu/script.sh
@@ -103,7 +103,7 @@ function generate_fake_packages() {
   cat SHA256SUMS | while read line; do
     local package_name=$(echo ${line} | cut -d',' -f1)
     local package_size=$(echo ${line} | cut -d',' -f2)
-    truncate --size "${package_size}" "downloads/${package_name}"
+    truncate -s "${package_size}" "downloads/${package_name}"
   done
 }
 
@@ -219,15 +219,15 @@ function add_package_to_list() {
   local package_filename=$(basename "${1}")
   local package_size=$(stat -c"%s" "${1}")
   printf "${package_filename},${package_size}\n" >> SHA256SUMS
-  truncate --size 0 "${1}"
-  truncate --size "${package_size}" "${1}"
+  truncate -s 0 "${1}"
+  truncate -s "${package_size}" "${1}"
 
   if [ -n "${2}" ]; then
     local debuginfo_package_filename=$(basename "${2}")
     local debuginfo_package_size=$(stat -c"%s" "${2}")
     printf "${debuginfo_package_filename},${debuginfo_package_size}\n" >> SHA256SUMS
-    truncate --size 0 "${2}"
-    truncate --size "${debuginfo_package_size}" "${2}"
+    truncate -s 0 "${2}"
+    truncate -s "${debuginfo_package_size}" "${2}"
   fi
 }
 
@@ -242,7 +242,7 @@ function process_packages() {
         printf "package_name = ${package_name} version = ${version} dbg_package_name = ${debug_package_name}\n"
         local debuginfo_package=$(find_debuginfo_package "${package_name}" "${version}" "${debug_package_name}")
 
-        truncate --size=0 error.log
+        truncate -s 0 error.log
 
         if [ -n "${debuginfo_package}" ]; then
           unpack_package ${package} ${debuginfo_package}

--- a/ubuntu/script.sh
+++ b/ubuntu/script.sh
@@ -25,7 +25,7 @@ get_package_urls() {
     urls="${urls} ${alt_url}/${main_path}/ ${alt_url}/${universe_path}/ ${alt_url}/${multiverse_path}/"
   fi
 
-  wget --waitretry=100 --retry-on-http-error=429 -o wget_packages_urls.log --progress=dot:mega -k ${urls}
+  ${WGET} -o wget_packages_urls.log -k ${urls}
   find . -name "index.html*" -exec grep -o "${url}/${main_path}/\(${package_name}\|${dbg_package_name}-dbg\|${dbgsym_package_name}-dbgsym\)_.*_\(i386\|amd64\).d.*eb\"" {} \; | cut -d'"' -f1
   find . -name "index.html*" -exec grep -o "${url}/${universe_path}/\(${package_name}\|${dbg_package_name}-dbg\|${dbgsym_package_name}-dbgsym\)_.*_\(i386\|amd64\).d.*eb\"" {} \; | cut -d'"' -f1
   find . -name "index.html*" -exec grep -o "${url}/${multiverse_path}/\(${package_name}\|${dbg_package_name}-dbg\|${dbgsym_package_name}-dbgsym\)_.*_\(i386\|amd64\).d.*eb\"" {} \; | cut -d'"' -f1
@@ -57,7 +57,7 @@ fetch_packages() {
   done
 
   sed -i -e 's/%2b/+/g' packages.txt
-  sort packages.txt | wget --waitretry=100 --retry-on-http-error=429 -o wget_packages.log --progress=dot:mega -P downloads -c -i -
+  sort packages.txt | ${WGET} -o wget_packages.log -P downloads -c -i -
 }
 
 function get_version() {

--- a/ubuntu/script.sh
+++ b/ubuntu/script.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+export DEBUGINFOD_URLS="https://debuginfod.ubuntu.com/"
+
 . $(dirname $0)/../common.sh
 
 URL="http://nl.archive.ubuntu.com/ubuntu/pool"

--- a/windows-graphics-drivers/script.sh
+++ b/windows-graphics-drivers/script.sh
@@ -87,7 +87,7 @@ fetch_and_process_drivers "${AMD_PATH}" "${AMD_SYMBOL_SERVER}"
 fetch_and_process_drivers "${INTEL_PATH}" "${INTEL_SYMBOL_SERVER}"
 fetch_and_process_drivers "${NVIDIA_PATH}" "${NVIDIA_SYMBOL_SERVER}"
 
-zip_symbols
+create_symbols_archive
 
 upload_symbols
 


### PR DESCRIPTION
This PR adds support for fetching debug information via debuginfod. Additionally the scripts have been sped up in a number of ways:
- The step that generates dummy packages is gone
- The network requests are cut down to just those needed to download previously unprocessed packages
- Network requests are retried in case of failures
- Less data is extracted from .deb packages
- Generating the final ZIP archive is much faster

Last but not least a few fix have been added to ensure the scrapers find all Debian & Ubuntu packages correctly.