### PR TITLE
firefox-flatpak: add 23.08 runtime

### DIFF
--- a/firefox-flatpak/script.sh
+++ b/firefox-flatpak/script.sh
@@ -6,7 +6,9 @@
 process_flatpak \
 	"org.mozilla.firefox/x86_64/stable" \
 	"org.freedesktop.Platform.GL.Debug.default/x86_64/22.08" \
-	"org.freedesktop.Platform.GL.Debug.default/x86_64/22.08-extra"
+	"org.freedesktop.Platform.GL.Debug.default/x86_64/22.08-extra" \
+	"org.freedesktop.Platform.GL.Debug.default/x86_64/23.08" \
+	"org.freedesktop.Platform.GL.Debug.default/x86_64/23.08-extra"
 
 create_symbols_archive
 


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1859509

[I'm not sure if I should be keeping 22.08 here, or if replacing it entirely is OK; let me know]