### PR TITLE
Add Debian/Ubuntu t64 packages.

### DIFF
--- a/debian/script.sh
+++ b/debian/script.sh
@@ -120,9 +120,13 @@ gvfs g/gvfs
 intel-media-va-driver i/intel-media-driver
 intel-media-va-driver-non-free i/intel-media-driver-non-free
 libasound2 a/alsa-lib
+libasound2t64 a/alsa-lib
 libatk1.0-0 a/atk1.0
+libatk1.0-0t64 a/atk1.0
 libatk-bridge2.0-0 a/at-spi2-atk
+libatk-bridge2.0-0t64 a/at-spi2-atk
 libatspi2.0-0 a/at-spi2-core
+libatspi2.0-0t64 a/at-spi2-core
 libavcodec[0-9][0-9] f/ffmpeg
 libavcodec[0-9][0-9] f/ffmpeg-dmo libavcodec[0-9][0-9] libavcodec[0-9][0-9] http://deb-multimedia.org/pool
 libavutil[0-9][0-9] f/ffmpeg
@@ -131,6 +135,7 @@ libc6 g/glibc
 libcairo2 c/cairo
 libcloudproviders0 libc/libcloudproviders
 libcups2 c/cups
+libcups2t64 c/cups
 libdbus-1-3 d/dbus
 libdbus-glib-1-2 d/dbus-glib
 libdrm2 libd/libdrm
@@ -143,6 +148,7 @@ libegl1-mesa-drivers m/mesa
 libegl-mesa0 m/mesa
 libepoxy0 libe/libepoxy
 libevent-2.[0-9]-[0-9] libe/libevent libevent libevent-2.[0-9]-[0-9]
+libevent-2.[0-9]-[0-9]t64 libe/libevent libevent libevent-2.[0-9]-[0-9]t64
 libexpat1 e/expat
 libfam0 f/fam
 libffi[0-9] libf/libffi
@@ -159,10 +165,13 @@ libgdk-pixbuf-2.0-0 g/gdk-pixbuf
 libgdk-pixbuf2.0-0 g/gdk-pixbuf
 libgl1-mesa-dri m/mesa
 libglib2.0-0 g/glib2.0
+libglib2.0-0t64 g/glib2.0
 libglx0 libg/libglvnd
 libglx-mesa0 m/mesa
 libgtk-3-0 g/gtk+3.0
+libgtk-3-0t64 g/gtk+3.0
 libhwy1 h/highway
+libhwy1t64 h/highway
 libibus-1.0-5 i/ibus
 libice6 libi/libice
 libicu[0-9][0-9] i/icu
@@ -177,9 +186,11 @@ libpcre2-8-0 p/pcre2
 libpcre3 p/pcre3
 libpcsclite1 p/pcsc-lite
 libpipewire-0.3-0 p/pipewire
+libpipewire-0.3-0t64 p/pipewire
 libpixman-1-0 p/pixman
 libpng12-0 libp/libpng
 libpng16-16 libp/libpng1.6
+libpng16-16t64 libp/libpng1.6
 libproxy1-plugin-gsettings libp/libproxy
 libproxy1v5 libp/libproxy
 libpulse0 p/pulseaudio
@@ -193,6 +204,7 @@ libstdc++6 g/gcc-12
 libstdc++6 g/gcc-13
 libsystemd0 s/systemd
 libtcmalloc-minimal4 g/google-perftools
+libtcmalloc-minimal4t64 g/google-perftools
 libthai0 libt/libthai
 libva2 libv/libva
 libvpx[0-9] libv/libvpx

--- a/ubuntu/script.sh
+++ b/ubuntu/script.sh
@@ -123,15 +123,20 @@ gvfs g/gvfs
 intel-media-va-driver i/intel-media-driver
 intel-media-va-driver-non-free i/intel-media-driver-non-free
 libasound2 a/alsa-lib
+libasound2t64 a/alsa-lib
 libatk1.0-0 a/atk1.0
+libatk1.0-0t64 a/atk1.0
 libatk-bridge2.0-0 a/at-spi2-atk
+libatk-bridge2.0-0t64 a/at-spi2-atk
 libatspi2.0-0 a/at-spi2-core
+libatspi2.0-0t64 a/at-spi2-core
 libavcodec[0-9][0-9] f/ffmpeg
 libavutil[0-9][0-9] f/ffmpeg
 libc6 g/glibc
 libcairo2 c/cairo
 libcloudproviders0 libc/libcloudproviders
 libcups2 c/cups
+libcups2t64 c/cups
 libdbus-1-3 d/dbus
 libdbus-glib-1-2 d/dbus-glib
 libdrm2 libd/libdrm
@@ -144,6 +149,7 @@ libegl1-mesa-drivers m/mesa
 libegl-mesa0 m/mesa
 libepoxy0 libe/libepoxy
 libevent-2.[0-9]-[0-9] libe/libevent libevent libevent-2.[0-9]-[0-9]
+libevent-2.[0-9]-[0-9]t64 libe/libevent libevent libevent-2.[0-9]-[0-9]t64
 libexpat1 e/expat
 libfam0 f/fam
 libffi[0-9] libf/libffi
@@ -160,10 +166,13 @@ libgdk-pixbuf-2.0-0 g/gdk-pixbuf
 libgdk-pixbuf2.0-0 g/gdk-pixbuf
 libgl1-mesa-dri m/mesa
 libglib2.0-0 g/glib2.0
+libglib2.0-0t64 g/glib2.0
 libglx0 libg/libglvnd
 libglx-mesa0 m/mesa
 libgtk-3-0 g/gtk+3.0
+libgtk-3-0t64 g/gtk+3.0
 libhwy1 h/highway
+libhwy1t64 h/highway
 libibus-1.0-5 i/ibus
 libice6 libi/libice
 libicu[0-9][0-9] i/icu
@@ -178,9 +187,11 @@ libpcre2-8-0 p/pcre2
 libpcre3 p/pcre3
 libpcsclite1 p/pcsc-lite
 libpipewire-0.3-0 p/pipewire
+libpipewire-0.3-0t64 p/pipewire
 libpixman-1-0 p/pixman
 libpng12-0 libp/libpng
 libpng16-16 libp/libpng1.6
+libpng16-16t64 libp/libpng1.6
 libproxy1-plugin-gsettings libp/libproxy
 libproxy1v5 libp/libproxy
 libpulse0 p/pulseaudio
@@ -194,6 +205,7 @@ libstdc++6 g/gcc-12
 libstdc++6 g/gcc-13
 libsystemd0 s/systemd
 libtcmalloc-minimal4 g/google-perftools
+libtcmalloc-minimal4t64 g/google-perftools
 libthai0 libt/libthai
 libva2 libv/libva
 libvpx[0-9] libv/libvpx


### PR DESCRIPTION
Debian is [making some changes][t64-goal] to support 64-bit `time_t` on some 32-bit platforms (most importantly ARM).  As part of this, a number of library packages' names have changed to add a `t64` suffix on *all* platforms, including ones like amd64 that always used a 64-bit `time_t`.

Ubuntu has incorporated these changes in 24.04 LTS (Noble Numbat), their latest release, so their users will also be affected.

We've already seen Firefox crash reports where stack unwinding failed because these scripts didn't know to scrape the new packages.  I've edited them to add the `t64` versions; I found the affected packages with this small shell script:

```
awk '/packages=/,/^"/{if(NF>1){print$1}}' script.sh | while read pkg
do apt-cache show ${pkg}t64 >/dev/null 2>&1 && echo UPDATE $pkg; done
```

[t64-goal]: https://wiki.debian.org/ReleaseGoals/64bit-time#Goal_description