### PR TITLE
Split symbols zip by individual file instead of entire directory

### DIFF
--- a/common.sh
+++ b/common.sh
@@ -112,7 +112,7 @@ function get_soname {
 function create_symbols_archive() {
   cd symbols
   archive="${artifact_filenames[-1]}"
-  for path in $(ls -A); do
+  for path in $(find -type f -name '*.sym'); do
     7zz a "../${archive}" "${path}"
     if [ $(stat -c "%s" "../${archive}") -gt $artifact_max_size ]; then
       artifact_index=$((artifact_index + 1))


### PR DESCRIPTION
Some directories end up big enough that adding one gets us from "below the 1GB mark" to "too big for tecken to process within 5 minutes".  Add one .sym file at a time to the zip file instead, until we reach 1GB.