### PR TITLE
rpi-os: Add mesa-libgallium

### DIFF
--- a/raspberry-pi-os/script.sh
+++ b/raspberry-pi-os/script.sh
@@ -143,6 +143,7 @@ libpulse0 p/pulseaudio
 libspa-0.2-modules p/pipewire
 libspeechd2 s/speech-dispatcher
 libwayland-client0 w/wayland
+mesa-libgallium m/mesa
 mesa-va-drivers m/mesa
 mesa-vulkan-drivers m/mesa
 zlib1g z/zlib


### PR DESCRIPTION
Add mesa-libgallium to the packages to scrape for raspberry pi os, it's heavily used in the graphics drivers / rendering